### PR TITLE
Add joystick controls and improved movement

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
 <body>
 <canvas id="gl"></canvas>
 <div id="crosshair"></div>
+<div id="joyL" class="joystick"><div class="inner"></div></div>
+<div id="joyR" class="joystick"><div class="inner"></div></div>
 <div id="ui">
   <div id="hp" class="panel">HP: <span id="hpVal">100</span></div>
   <div id="ammo" class="panel">Ammo: <span id="ammoVal">30</span></div>

--- a/main.js
+++ b/main.js
@@ -2,7 +2,7 @@ import { initEngine, renderFrame, setGlitch, kickFov } from './engine.js';
 import { generateOrgan } from './organGen.js';
 import { guns, reloadShader } from './shaderGuns.js';
 import { updateBlood, spawnBlood, getBlood } from './goreSim.js';
-import { initMeta, mutateRules } from './metaMutate.js';
+import { initMeta, mutateRules, getRules } from './metaMutate.js';
 
 const dev = new URLSearchParams(location.search).get('dev') === '1';
 const canvas = document.getElementById('gl');
@@ -12,28 +12,66 @@ initEngine(gl, canvas, dev);
 initMeta();
 
 const cross=document.getElementById('crosshair');
+const hasTouch = 'ontouchstart' in window || navigator.maxTouchPoints>0;
+const joyL=document.getElementById('joyL');
+const joyR=document.getElementById('joyR');
+const joyLInner=joyL.querySelector('.inner');
+const joyRInner=joyR.querySelector('.inner');
+let moveJoy={x:0,y:0},aimJoy={x:0,y:0};
+if(hasTouch){
+  cross.style.display='none';
+}else{
+  joyL.style.display='none';
+  joyR.style.display='none';
+}
 let locked=false,cx=window.innerWidth/2,cy=window.innerHeight/2;
-canvas.addEventListener('click',()=>{
-  if(!locked) canvas.requestPointerLock();
-  else fire();
-});
-document.addEventListener('pointerlockchange',()=>{
-  locked=document.pointerLockElement===canvas;
-});
-document.addEventListener('mousemove',e=>{
-  if(!locked)return;
-  cx=Math.min(window.innerWidth,Math.max(0,cx+e.movementX));
-  cy=Math.min(window.innerHeight,Math.max(0,cy+e.movementY));
-  cross.style.left=cx+'px';
-  cross.style.top=cy+'px';
-});
+if(!hasTouch){
+  canvas.addEventListener('click',()=>{
+    if(!locked) canvas.requestPointerLock();
+    else fire();
+  });
+  document.addEventListener('pointerlockchange',()=>{
+    locked=document.pointerLockElement===canvas;
+  });
+  document.addEventListener('mousemove',e=>{
+    if(!locked)return;
+    cx=Math.min(window.innerWidth,Math.max(0,cx+e.movementX));
+    cy=Math.min(window.innerHeight,Math.max(0,cy+e.movementY));
+    cross.style.left=cx+'px';
+    cross.style.top=cy+'px';
+  });
+} 
+else {
+  const joyUpdate=(el,inner,vec)=>e=>{
+    const r=el.clientWidth/2;
+    const rect=el.getBoundingClientRect();
+    const x=e.touches?e.touches[0].clientX:e.clientX;
+    const y=e.touches?e.touches[0].clientY:e.clientY;
+    const dx=x-(rect.left+r);
+    const dy=y-(rect.top+r);
+    const nx=Math.max(-r,Math.min(r,dx));
+    const ny=Math.max(-r,Math.min(r,dy));
+    inner.style.left=r+nx+'px';
+    inner.style.top=r+ny+'px';
+    vec.x=nx/r;vec.y=ny/r;
+  };
+  let lActive=false,rActive=false;
+  joyL.addEventListener('pointerdown',e=>{lActive=true;joyUpdate(joyL,joyLInner,moveJoy)(e);});
+  joyL.addEventListener('pointermove',e=>{if(lActive)joyUpdate(joyL,joyLInner,moveJoy)(e);});
+  joyL.addEventListener('pointerup',()=>{lActive=false;moveJoy.x=moveJoy.y=0;joyLInner.style.left='50%';joyLInner.style.top='50%';});
+  joyL.addEventListener('pointercancel',()=>{lActive=false;moveJoy.x=moveJoy.y=0;joyLInner.style.left='50%';joyLInner.style.top='50%';});
+  joyR.addEventListener('pointerdown',e=>{rActive=true;joyUpdate(joyR,joyRInner,aimJoy)(e);});
+  joyR.addEventListener('pointermove',e=>{if(rActive)joyUpdate(joyR,joyRInner,aimJoy)(e);});
+  joyR.addEventListener('pointerup',()=>{rActive=false;aimJoy.x=aimJoy.y=0;joyRInner.style.left='50%';joyRInner.style.top='50%';fire();});
+  joyR.addEventListener('pointercancel',()=>{rActive=false;aimJoy.x=aimJoy.y=0;joyRInner.style.left='50%';joyRInner.style.top='50%';});
+}
 
 const CHUNK_SIZE=0.25;
 let chunkX=0,chunkY=0;
 const loadedChunks={};
 loadedChunks['0,0']=generateOrgan(0,0);
 
-const player={x:0.5,y:0.5,hp:100};
+const player={x:0.5,y:0.5,vx:0,vy:0,hp:100};
 let bullets=[],enemies=[],wave=7,difficulty=1,kills=0;
 let elapsed=0;
 const keys={};
@@ -41,8 +79,13 @@ const hpVal=document.getElementById('hpVal');
 const fpsEl=document.getElementById('fps');
 
 function fire(){
-  const dx=cx/window.innerWidth-0.5;
-  const dy=cy/window.innerHeight-0.5;
+  let dx,dy;
+  if(hasTouch){
+    dx=aimJoy.x;dy=aimJoy.y;
+  }else{
+    dx=cx/window.innerWidth-0.5;
+    dy=cy/window.innerHeight-0.5;
+  }
   const l=Math.hypot(dx,dy)||1;
   bullets.push({x:player.x,y:player.y,dx:dx/l*0.6,dy:dy/l*0.6,life:2});
   setGlitch(true);
@@ -78,14 +121,21 @@ function loop(ts){
   last = ts;
   elapsed += dt;
   if(dev) fpsEl.textContent = Math.round(1/dt)+" FPS";
-  // simple player movement
-  const speed=0.3;
-  if(keys['w']) player.y-=speed*dt;
-  if(keys['s']) player.y+=speed*dt;
-  if(keys['a']) player.x-=speed*dt;
-  if(keys['d']) player.x+=speed*dt;
-  player.x=Math.max(0,Math.min(1,player.x));
-  player.y=Math.max(0,Math.min(1,player.y));
+  // movement with friction + gravity
+  const rules=getRules();
+  let ax=(keys['d']?1:0)-(keys['a']?1:0)+moveJoy.x;
+  let ay=(keys['s']?1:0)-(keys['w']?1:0)+moveJoy.y;
+  if(ax||ay){
+    const l=Math.hypot(ax,ay);ax/=l;ay/=l;
+    const accel=0.6;
+    player.vx+=ax*accel*dt;
+    player.vy+=ay*accel*dt;
+  }
+  player.vy+=0.4*rules.gravity*dt;
+  player.vx*=rules.friction;
+  player.vy*=rules.friction;
+  player.x+=player.vx*dt;
+  player.y+=player.vy*dt;
   const cxx=Math.floor(player.x/CHUNK_SIZE);
   const cyy=Math.floor(player.y/CHUNK_SIZE);
   if(cxx!==chunkX||cyy!==chunkY){
@@ -97,7 +147,7 @@ function loop(ts){
     }
   }
   bullets.forEach(b=>{b.x+=b.dx*dt;b.y+=b.dy*dt;b.life-=dt;});
-  bullets=bullets.filter(b=>b.life>0&&b.x>-0.1&&b.x<1.1&&b.y>-0.1&&b.y<1.1);
+  bullets=bullets.filter(b=>b.life>0&&Math.abs(b.x-player.x)<1&&Math.abs(b.y-player.y)<1);
   enemies.forEach(e=>{const dx=player.x-e.x,dy=player.y-e.y,l=Math.hypot(dx,dy)||1;e.x+=dx/l*0.1*dt;e.y+=dy/l*0.1*dt;});
   for(let i=bullets.length-1;i>=0;i--)for(let j=enemies.length-1;j>=0;j--){
     const dx=bullets[i].x-enemies[j].x,dy=bullets[i].y-enemies[j].y;
@@ -131,14 +181,30 @@ function loop(ts){
   }
   wave-=dt; if(wave<=0){spawnWave(difficulty);wave=7;}
   updateBlood(dt);
-  renderFrame(dt,bullets,enemies,getBlood());
+  const offX=player.x-0.5,offY=player.y-0.5;
+  const rb=bullets.map(b=>({x:b.x-offX,y:b.y-offY}));
+  const re=enemies.map(e=>({x:e.x-offX,y:e.y-offY}));
+  const bl=getBlood().map(b=>({x:b.x-offX,y:b.y-offY}));
+  renderFrame(dt,rb,re,bl);
   requestAnimationFrame(loop);
 }
 requestAnimationFrame(loop);
 
 window.addEventListener('resize', ()=>initEngine(gl, canvas, dev));
 window.addEventListener('keydown', e=>{
-  keys[e.key]=true;
-  if(e.key==='m') mutateRules();
+  const k=e.key;
+  if(k==='ArrowUp') keys['w']=true;
+  else if(k==='ArrowDown') keys['s']=true;
+  else if(k==='ArrowLeft') keys['a']=true;
+  else if(k==='ArrowRight') keys['d']=true;
+  keys[k]=true;
+  if(k==='m') mutateRules();
 });
-window.addEventListener('keyup', e=>{keys[e.key]=false;});
+window.addEventListener('keyup', e=>{
+  const k=e.key;
+  if(k==='ArrowUp') keys['w']=false;
+  else if(k==='ArrowDown') keys['s']=false;
+  else if(k==='ArrowLeft') keys['a']=false;
+  else if(k==='ArrowRight') keys['d']=false;
+  keys[k]=false;
+});

--- a/styles.css
+++ b/styles.css
@@ -11,3 +11,7 @@ canvas{display:block;width:100%;height:100%;}
 #crosshair:before,#crosshair:after{content:'';position:absolute;background:currentColor}
 #crosshair:before{left:50%;top:0;width:2px;height:100%;margin-left:-1px}
 #crosshair:after{top:50%;left:0;width:100%;height:2px;margin-top:-1px}
+.joystick{position:absolute;width:80px;height:80px;border:1px solid rgba(255,255,255,0.2);border-radius:50%;bottom:20px;touch-action:none}
+#joyL{left:20px}
+#joyR{right:20px}
+.joystick .inner{position:absolute;width:40px;height:40px;background:rgba(255,255,255,0.2);border-radius:50%;top:50%;left:50%;margin:-20px}


### PR DESCRIPTION
## Summary
- add joystick elements for touch controls
- style on-screen joysticks
- implement WASD/arrow key and touch joystick movement with friction and gravity
- center camera by offsetting world render positions

## Testing
- `node -c main.js`
- `node -c engine.js`
- `node -c goreSim.js`
- `node -c metaMutate.js`
- `node -c organGen.js`
- `node -c shaderGuns.js`
- `node -e "require('./main.js')"` *(fails: ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686248f3e3348332b20896a1471a3ea3