### PR TITLE
Add simple auto-fire 3D mode

### DIFF
--- a/map3d.js
+++ b/map3d.js
@@ -2,6 +2,11 @@ import * as THREE from './three.module.js';
 import { PointerLockControls } from './PointerLockControls.js';
 
 let camera, scene, renderer, controls;
+let enemies = [];
+let raycaster;
+let crosshair;
+let lastShot = 0;
+
 init();
 animate();
 
@@ -9,6 +14,8 @@ function init(){
   const canvas = document.getElementById('gl');
   renderer = new THREE.WebGLRenderer({canvas});
   renderer.setSize(window.innerWidth, window.innerHeight);
+  crosshair = document.getElementById('crosshair');
+  raycaster = new THREE.Raycaster();
 
   scene = new THREE.Scene();
   scene.background = new THREE.Color(0x050505);
@@ -25,11 +32,14 @@ function init(){
   floor.rotation.x = -Math.PI/2;
   scene.add(floor);
 
-  const boxGeo = new THREE.BoxGeometry(1,1,1);
+  const boxGeo = new THREE.BoxGeometry(0.5,0.5,0.5);
   const boxMat = new THREE.MeshNormalMaterial();
-  const box = new THREE.Mesh(boxGeo, boxMat);
-  box.position.set(0.0,0.5,-3.0);
-  scene.add(box);
+  for(let i=0;i<5;i++){
+    const box = new THREE.Mesh(boxGeo, boxMat.clone());
+    box.position.set(Math.random()*6-3,0.25,Math.random()*-6);
+    scene.add(box);
+    enemies.push(box);
+  }
 
   window.addEventListener('resize', onResize);
 }
@@ -43,5 +53,19 @@ function onResize(){
 function animate(){
   requestAnimationFrame(animate);
   controls.update();
+  raycaster.setFromCamera(new THREE.Vector2(0,0), camera);
+  const hits = raycaster.intersectObjects(enemies);
+  if(hits.length>0){
+    crosshair.style.color='#ff0040';
+    const now=performance.now();
+    if(now-lastShot>500){
+      const enemy=hits[0].object;
+      scene.remove(enemy);
+      enemies.splice(enemies.indexOf(enemy),1);
+      lastShot=now;
+    }
+  }else{
+    crosshair.style.color='';
+  }
   renderer.render(scene, camera);
 }


### PR DESCRIPTION
## Summary
- add enemies and raycast interaction in `map3d.js`
- start shooting automatically when crosshair hovers an enemy
- highlight crosshair when hitting a target

## Testing
- `node --check map3d.js`
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_6862cb6c4f5c833288b6a398271ba8be