### PR TITLE
Add shader fragment inventory system

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -58,7 +58,7 @@ function drawPoints(arr,color,size){
   gl.drawArrays(gl.POINTS,0,arr.length);
 }
 
-export function renderFrame(dt,bullets,enemies,blood,bulletSize){
+export function renderFrame(dt,bullets,enemies,blood,items,bulletSize){
   if(glitch){
     glitchTime-=dt;
     if(glitchTime<=0) glitch=false;
@@ -71,6 +71,7 @@ export function renderFrame(dt,bullets,enemies,blood,bulletSize){
   gl.clear(gl.COLOR_BUFFER_BIT);
   drawPoints(enemies,[0,1,0],16.0);
   drawPoints(bullets,[1,0,0.3],bulletSize);
+  drawPoints(items,[0,0.8,1.0],8.0);
   drawPoints(blood,[0.8,0,0],4.0);
 }
 

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 <div id="joyR" class="joystick"><div class="inner"></div></div>
 <div id="ui">
   <div id="hp" class="panel">HP: <span id="hpVal">100</span></div>
-  <div id="ammo" class="panel">Ammo: <span id="ammoVal">30</span></div>
+  <div id="ammo" class="panel">Mods: <span id="ammoVal">0</span></div>
   <div id="meta" class="panel">Meta</div>
   <div id="fps" class="panel" style="display:none">0 FPS</div>
 </div>


### PR DESCRIPTION
## Summary
- let player collect shader fragments when enemies die
- keep fragments in inventory and use duplicates to raise level
- render fragment drops in game and display count in UI
- press `E` to apply the best fragment to the active gun

## Testing
- `node --check shaderGuns.js && node --check main.js && node --check engine.js`

------
https://chatgpt.com/codex/tasks/task_e_6862d991e4888332bebd79a1a254efbf