### PR TITLE
Add meta mutation system with persistence and end‑of‑run report

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -1,9 +1,10 @@
 // Simplified WebGL engine. Zayebis'.
+import { getRules } from './metaMutate.js';
 let gl, canvas, devMode;
 let glitch = false, glitchTime=0;
 let time = 0;
 let program, buf, locPos, locColor, locSize;
-let camFov = 1, targetFov = 1;
+let camFov = 1, targetFov = 1, baseFov = 1;
 
 export function initEngine(g,c,dev){
   gl=g;canvas=c;devMode=dev;
@@ -61,6 +62,7 @@ function drawPoints(arr,color,size){
 
 export function renderFrame(dt,bullets,enemies,blood,items,bulletSize){
   time += dt;
+  baseFov=getRules().FOV||1;
   const pulse = 0.5 + Math.sin(time*3.0)*0.5;
   if(glitch){
     glitchTime-=dt;
@@ -69,8 +71,8 @@ export function renderFrame(dt,bullets,enemies,blood,items,bulletSize){
   } else {
     gl.clearColor(0.02*pulse,0.02,0.02*pulse,1);
   }
-  camFov += (targetFov - camFov) * dt * 8.0;
-  targetFov += (1 - targetFov) * dt * 2.0;
+  camFov += (targetFov*baseFov - camFov) * dt * 8.0;
+  targetFov += (baseFov - targetFov) * dt * 2.0;
   gl.clear(gl.COLOR_BUFFER_BIT);
   drawPoints(enemies,[0,pulse,0],16.0);
   drawPoints(bullets,[1,0,0.3],bulletSize);

--- a/goreSim.js
+++ b/goreSim.js
@@ -14,7 +14,10 @@ export function spawnBlood(x,y,state='normal',amount=10){
     const excess=blood.length-limit;
     for(let i=0;i<excess;i++){
       blood[i].life*=0.5;
-      if(playerRef) playerRef.hp=Math.min(100,playerRef.hp+0.1);
+      if(playerRef){
+        const regen=getRules().regen||0;
+        playerRef.hp=Math.min(100,playerRef.hp+0.1*regen);
+      }
     }
     blood.splice(0,excess);
   }

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 <div id="joyR" class="joystick"><div class="inner"></div></div>
 <div id="ui">
   <div id="meta" class="panel">Meta</div>
+  <div id="report" class="panel" style="display:none"></div>
   <div id="perf" class="panel">Particles: <input id="bloodCap" type="range" min="100" max="1500"></div>
   <div id="fps" class="panel" style="display:none">0 FPS</div>
 </div>

--- a/metaMutate.js
+++ b/metaMutate.js
@@ -1,4 +1,4 @@
-let rules={gravity:1,friction:0.9,enemySpeed:1,FOV:1,bloodLimit:500};
+let rules={gravity:1,friction:0.9,enemySpeed:1,FOV:1,bloodLimit:500,regen:1};
 
 function defaultBloodLimit(){
   const mem=navigator.deviceMemory||4;
@@ -18,9 +18,16 @@ export function initMeta(){
 export function mutateRules(){
   const keys=Object.keys(rules);
   const k=keys[Math.floor(Math.random()*keys.length)];
-  rules[k]*=0.5+Math.random();
+  if(k==='regen'){
+    rules[k]=rules[k]>0?0:1;
+  } else if(k==='bloodLimit') {
+    rules[k]=Math.max(100,Math.floor(rules[k]*(0.5+Math.random())));
+  } else {
+    rules[k]*=0.5+Math.random();
+  }
   localStorage.setItem('meatRules',JSON.stringify(rules));
   console.log('Meta-mutation:',k,rules[k]);
+  return {key:k,value:rules[k]};
 }
 
 export function setPerformanceSettings(opts={}){
@@ -30,4 +37,10 @@ export function setPerformanceSettings(opts={}){
 
 export function getRules(){
   return rules;
+}
+
+export function formatRules(){
+  return Object.entries(rules)
+    .map(([k,v])=>`${k}: ${typeof v==='number'?v.toFixed(2):v}`)
+    .join('\n');
 }

--- a/styles.css
+++ b/styles.css
@@ -1,10 +1,11 @@
 html,body{width:100vw;height:100vh;margin:0;overflow:hidden;touch-action:none;background:#050505;background:radial-gradient(circle,#0a0015,#050505);color:#faffff;font-family:monospace}
 canvas{display:block;width:100%;height:100%;}
-.panel{position:absolute;padding:4px 8px;background:rgba(0,0,0,0.3);backdrop-filter:blur(6px);text-shadow:0 0 6px currentColor;border:1px solid rgba(255,255,255,0.1)}
+.panel{position:absolute;padding:4px 8px;background:rgba(0,0,0,0.3);backdrop-filter:blur(6px);text-shadow:0 0 6px currentColor;border:1px solid rgba(255,255,255,0.1);white-space:pre}
 #meta{bottom:4px;left:4px}
 #perf{bottom:26px;left:4px}
 #perf input{width:80px}
 #fps{bottom:4px;right:4px}
+#report{top:40%;left:50%;transform:translate(-50%,-50%);text-align:center}
 #shaderEdit{position:absolute;bottom:40px;left:4px;width:50%;height:30%;z-index:1000;background:#000;color:#0f0;font-family:monospace}
 #glitchBtn{position:absolute;top:4px;left:120px;z-index:999}
 #crosshair{position:absolute;top:50%;left:50%;width:20px;height:20px;margin:-10px 0 0 -10px;pointer-events:none;color:#faffff}


### PR DESCRIPTION
## Summary
- extend meta rules with `regen` and expose helper to format rules
- apply random rule mutation on player death and update UI
- display current rules in new meta and report panels
- incorporate rules in engine, gore simulation and enemy creation
- persist settings in `localStorage`

## Testing
- `node --check metaMutate.js engine.js main.js goreSim.js`

------
https://chatgpt.com/codex/tasks/task_e_6862e09a63448332892a59be1a20374e