### PR TITLE
Add simple map rendering

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -60,7 +60,7 @@ function drawPoints(arr,color,size){
   gl.drawArrays(gl.POINTS,0,arr.length);
 }
 
-export function renderFrame(dt,bullets,enemies,blood,items,bulletSize){
+export function renderFrame(dt,bullets,enemies,blood,items,map,bulletSize,mapCellSize){
   time += dt;
   baseFov=getRules().FOV||1;
   const pulse = 0.5 + Math.sin(time*3.0)*0.5;
@@ -74,6 +74,8 @@ export function renderFrame(dt,bullets,enemies,blood,items,bulletSize){
   camFov += (targetFov*baseFov - camFov) * dt * 8.0;
   targetFov += (baseFov - targetFov) * dt * 2.0;
   gl.clear(gl.COLOR_BUFFER_BIT);
+  const cellPixels = mapCellSize/camFov*canvas.height;
+  drawPoints(map,[0.3,0.3,0.3],cellPixels);
   drawPoints(enemies,[0,pulse,0],16.0);
   drawPoints(bullets,[1,0,0.3],bulletSize);
   drawPoints(items,[0,0.8,1.0],8.0);

--- a/main.js
+++ b/main.js
@@ -351,7 +351,13 @@ function loop(ts){
   const re=enemies.map(e=>({x:e.x-offX,y:e.y-offY}));
   const bl=getBlood().map(b=>({x:b.x-offX,y:b.y-offY}));
   const fi=fragItems.map(f=>({x:f.x-offX,y:f.y-offY}));
-  renderFrame(dt,rb,re,bl,fi,guns[currentGun].size);
+  const mapCells=[];
+  for(const k in loadedChunks){
+    for(const c of loadedChunks[k]){
+      mapCells.push({x:c.x+c.w*0.5-offX,y:c.y+c.h*0.5-offY});
+    }
+  }
+  renderFrame(dt,rb,re,bl,fi,mapCells,guns[currentGun].size,CHUNK_SIZE);
   requestAnimationFrame(loop);
 }
 requestAnimationFrame(loop);


### PR DESCRIPTION
## Summary
- draw map cells as small squares in the WebGL canvas
- pass chunk information to renderer

## Testing
- `node --check main.js`
- `node --check engine.js`


------
https://chatgpt.com/codex/tasks/task_e_6862e289e42483329c5ef7339cdb3d47