### PR TITLE
Fix three.js imports

### DIFF
--- a/OrbitControls.js
+++ b/OrbitControls.js
@@ -1,15 +1,15 @@
 import {
-	EventDispatcher,
-	MOUSE,
-	Quaternion,
-	Spherical,
-	TOUCH,
-	Vector2,
-	Vector3,
-	Plane,
-	Ray,
-	MathUtils
-} from 'three';
+       EventDispatcher,
+       MOUSE,
+       Quaternion,
+       Spherical,
+       TOUCH,
+       Vector2,
+       Vector3,
+       Plane,
+       Ray,
+       MathUtils
+} from './three.module.js';
 
 // OrbitControls performs orbiting, dollying (zooming), and panning.
 // Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).

--- a/PointerLockControls.js
+++ b/PointerLockControls.js
@@ -1,8 +1,8 @@
 import {
-	Euler,
-	EventDispatcher,
-	Vector3
-} from 'three';
+       Euler,
+       EventDispatcher,
+       Vector3
+} from './three.module.js';
 
 const _euler = new Euler( 0, 0, 0, 'YXZ' );
 const _vector = new Vector3();


### PR DESCRIPTION
## Summary
- use local `three.module.js` when importing in `PointerLockControls.js`
- do the same in `OrbitControls.js`

## Testing
- `python3 -m http.server`

------
https://chatgpt.com/codex/tasks/task_e_6862f605c6ec8332a1b99d5a7b4a86ba