### PR TITLE
Fix map3d controls call

### DIFF
--- a/map3d.js
+++ b/map3d.js
@@ -64,7 +64,7 @@ function onResize(){
 
 function animate(){
   requestAnimationFrame(animate);
-  controls.update();
+  // controls.update();
   const t=performance.now()*0.001;
   const p=0.5+Math.sin(t*2)*0.5;
   if(organMat){


### PR DESCRIPTION
## Summary
- avoid calling missing `controls.update()` in the animation loop

## Testing
- `node --check map3d.js`
- `python3 -m http.server 8000` (manual) and `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_6862f9df0a3c8332a28731b2eda93b75