### PR TITLE
Fix joystick UI overlap and update mobile aiming

### DIFF
--- a/main.js
+++ b/main.js
@@ -21,8 +21,11 @@ const joyR=document.getElementById('joyR');
 const joyLInner=joyL.querySelector('.inner');
 const joyRInner=joyR.querySelector('.inner');
 let moveJoy={x:0,y:0},aimJoy={x:0,y:0};
+const JOY_CROSS_RANGE=60;
 if(hasTouch){
-  cross.style.display='none';
+  cross.style.display='block';
+  cross.style.left='50%';
+  cross.style.top='50%';
 }else{
   joyL.style.display='none';
   joyR.style.display='none';
@@ -48,7 +51,7 @@ if(!hasTouch){
   });
 } 
 else {
-  const joyUpdate=(el,inner,vec)=>e=>{
+  const joyUpdate=(el,inner,vec,isAim)=>e=>{
     const r=el.clientWidth/2;
     const rect=el.getBoundingClientRect();
     const x=e.touches?e.touches[0].clientX:e.clientX;
@@ -60,16 +63,22 @@ else {
     inner.style.left=r+nx+'px';
     inner.style.top=r+ny+'px';
     vec.x=nx/r;vec.y=ny/r;
+    if(isAim){
+      cx=window.innerWidth/2+vec.x*JOY_CROSS_RANGE;
+      cy=window.innerHeight/2+vec.y*JOY_CROSS_RANGE;
+      cross.style.left=cx+'px';
+      cross.style.top=cy+'px';
+    }
   };
   let lActive=false,rActive=false;
-  joyL.addEventListener('pointerdown',e=>{lActive=true;joyUpdate(joyL,joyLInner,moveJoy)(e);});
-  joyL.addEventListener('pointermove',e=>{if(lActive)joyUpdate(joyL,joyLInner,moveJoy)(e);});
+  joyL.addEventListener('pointerdown',e=>{lActive=true;joyUpdate(joyL,joyLInner,moveJoy,false)(e);});
+  joyL.addEventListener('pointermove',e=>{if(lActive)joyUpdate(joyL,joyLInner,moveJoy,false)(e);});
   joyL.addEventListener('pointerup',()=>{lActive=false;moveJoy.x=moveJoy.y=0;joyLInner.style.left='50%';joyLInner.style.top='50%';});
   joyL.addEventListener('pointercancel',()=>{lActive=false;moveJoy.x=moveJoy.y=0;joyLInner.style.left='50%';joyLInner.style.top='50%';});
-  joyR.addEventListener('pointerdown',e=>{rActive=true;joyUpdate(joyR,joyRInner,aimJoy)(e);});
-  joyR.addEventListener('pointermove',e=>{if(rActive)joyUpdate(joyR,joyRInner,aimJoy)(e);});
-  joyR.addEventListener('pointerup',()=>{rActive=false;aimJoy.x=aimJoy.y=0;joyRInner.style.left='50%';joyRInner.style.top='50%';fire();});
-  joyR.addEventListener('pointercancel',()=>{rActive=false;aimJoy.x=aimJoy.y=0;joyRInner.style.left='50%';joyRInner.style.top='50%';});
+  joyR.addEventListener('pointerdown',e=>{rActive=true;joyUpdate(joyR,joyRInner,aimJoy,true)(e);});
+  joyR.addEventListener('pointermove',e=>{if(rActive)joyUpdate(joyR,joyRInner,aimJoy,true)(e);});
+  joyR.addEventListener('pointerup',()=>{rActive=false;aimJoy.x=aimJoy.y=0;joyRInner.style.left='50%';joyRInner.style.top='50%';cx=window.innerWidth/2;cy=window.innerHeight/2;cross.style.left=cx+'px';cross.style.top=cy+'px';fire();});
+  joyR.addEventListener('pointercancel',()=>{rActive=false;aimJoy.x=aimJoy.y=0;joyRInner.style.left='50%';joyRInner.style.top='50%';cx=window.innerWidth/2;cy=window.innerHeight/2;cross.style.left=cx+'px';cross.style.top=cy+'px';});
 }
 
 const CHUNK_SIZE=0.25;

--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,8 @@
 html,body{width:100vw;height:100vh;margin:0;overflow:hidden;touch-action:none;background:#050505;background:radial-gradient(circle,#0a0015,#050505);color:#faffff;font-family:monospace}
 canvas{position:absolute;top:0;left:0;display:block;width:100%;height:100%;}
 .panel{position:absolute;padding:4px 8px;background:rgba(0,0,0,0.3);backdrop-filter:blur(6px);text-shadow:0 0 6px currentColor;border:1px solid rgba(255,255,255,0.1);white-space:pre}
-#meta{bottom:4px;left:4px}
-#perf{bottom:26px;left:4px}
+#meta{top:4px;left:4px}
+#perf{top:26px;left:4px}
 #perf input{width:80px}
 #fps{bottom:4px;right:4px}
 #report{top:40%;left:50%;transform:translate(-50%,-50%);text-align:center}
@@ -12,7 +12,7 @@ canvas{position:absolute;top:0;left:0;display:block;width:100%;height:100%;}
 #crosshair:before,#crosshair:after{content:'';position:absolute;background:currentColor}
 #crosshair:before{left:50%;top:0;width:2px;height:100%;margin-left:-1px}
 #crosshair:after{top:50%;left:0;width:100%;height:2px;margin-top:-1px}
-.joystick{position:absolute;width:80px;height:80px;border:1px solid rgba(255,255,255,0.2);border-radius:50%;bottom:20px;touch-action:none}
+.joystick{position:absolute;width:80px;height:80px;border:1px solid rgba(255,255,255,0.2);border-radius:50%;bottom:20px;touch-action:none;z-index:2}
 #joyL{left:20px}
 #joyR{right:20px}
 .joystick .inner{position:absolute;width:40px;height:40px;background:rgba(255,255,255,0.2);border-radius:50%;top:50%;left:50%;margin:-20px}


### PR DESCRIPTION
## Summary
- move info panels to the top-left so they don't block the left joystick
- show crosshair on touch devices and update it with the right joystick
- keep joysticks above other UI panels

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686306a8a6a88332a648a34e17d7e6e9