### PR TITLE
Add mobile joystick control for 3D camera

### DIFF
--- a/main.js
+++ b/main.js
@@ -21,6 +21,8 @@ const joyR=document.getElementById('joyR');
 const joyLInner=joyL.querySelector('.inner');
 const joyRInner=joyR.querySelector('.inner');
 let moveJoy={x:0,y:0},aimJoy={x:0,y:0};
+window.moveJoy = moveJoy;
+window.aimJoy = aimJoy;
 const JOY_CROSS_RANGE=60;
 if(hasTouch){
   cross.style.display='block';

--- a/map3d.js
+++ b/map3d.js
@@ -2,6 +2,10 @@ import * as THREE from './three.module.js';
 import { PointerLockControls } from './PointerLockControls.js';
 import { generateTunnelMesh, setSeed } from './organGen.js';
 
+const hasTouch = 'ontouchstart' in window || navigator.maxTouchPoints>0;
+const moveJoy = window.moveJoy || {x:0,y:0};
+const aimJoy = window.aimJoy || {x:0,y:0};
+
 let camera, scene, renderer, controls;
 let enemies = [];
 let light;
@@ -102,6 +106,17 @@ function animate(){
   const time=performance.now();
   const delta=(time-prevTime)/1000;
   prevTime=time;
+  if(hasTouch){
+    const rotSpeed=2.5;
+    const euler=new THREE.Euler(0,0,0,'YXZ');
+    euler.setFromQuaternion(camera.quaternion);
+    euler.y-=aimJoy.x*rotSpeed*delta;
+    euler.x-=aimJoy.y*rotSpeed*delta;
+    euler.x=Math.max(-Math.PI/2,Math.min(Math.PI/2,euler.x));
+    camera.quaternion.setFromEuler(euler);
+    controls.moveForward(-moveJoy.y*velocity*delta);
+    controls.moveRight(moveJoy.x*velocity*delta);
+  }
   if(moveForward) controls.moveForward(velocity*delta);
   if(moveBackward) controls.moveForward(-velocity*delta);
   if(moveLeft) controls.moveRight(-velocity*delta);


### PR DESCRIPTION
## Summary
- expose joystick vectors globally in `main.js`
- use those joystick vectors in `map3d.js` to control camera rotation and movement on touch devices

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68630b2d043483329e54fbf19a4ab72f