### PR TITLE
Improve touch UX and room generation

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,6 +14,11 @@ initEngine(gl, canvas, dev);
 initMeta();
 initGuns(gl);
 
+// Prevent text selection and system gestures
+document.addEventListener('selectstart',e=>e.preventDefault());
+document.addEventListener('contextmenu',e=>e.preventDefault());
+document.addEventListener('dblclick',e=>e.preventDefault());
+
 const cross=document.getElementById('crosshair');
 const hasTouch = 'ontouchstart' in window || navigator.maxTouchPoints>0;
 const joyL=document.getElementById('joyL');

--- a/organGen.js
+++ b/organGen.js
@@ -79,12 +79,23 @@ export function generateOrgan(cx,cy){
   const rnd=mulberry32((cx*73856093^cy*19349663^worldSeed)>>>0);
   const roomCount=1+Math.floor(rnd()*2);
   const dig=(lx,ly)=>{const key=lx+','+ly;if(!cellSet.has(key)){cellSet.add(key);cells.push({x:baseX+lx,y:baseY+ly});}};
+  const centers=[];
+  let prevCenter=null;
+  const connect=(a,b)=>{
+    let x=a.x,y=a.y;
+    while(x!==b.x){x+=Math.sign(b.x-x);dig(x,y);}
+    while(y!==b.y){y+=Math.sign(b.y-y);dig(x,y);}
+  };
   for(let i=0;i<roomCount;i++){
     const w=3+Math.floor(rnd()*3);
     const h=3+Math.floor(rnd()*3);
     const rx=Math.floor(rnd()*(SIZE-w));
     const ry=Math.floor(rnd()*(SIZE-h));
     for(let y=0;y<h;y++)for(let x=0;x<w;x++)dig(rx+x,ry+y);
+    const center={x:rx+(w>>1),y:ry+(h>>1)};
+    centers.push(center);
+    if(prevCenter) connect(prevCenter,center);
+    prevCenter=center;
   }
   // connect to edges
   const dirs=[[0,-1],[1,0],[0,1],[-1,0]];

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,4 @@
-html,body{width:100vw;height:100vh;margin:0;overflow:hidden;touch-action:none;background:#050505;background:radial-gradient(circle,#0a0015,#050505);color:#faffff;font-family:monospace}
+html,body{width:100vw;height:100vh;margin:0;overflow:hidden;touch-action:none;background:#050505;background:radial-gradient(circle,#0a0015,#050505);color:#faffff;font-family:monospace;-webkit-user-select:none;-ms-user-select:none;user-select:none;-webkit-touch-callout:none;-webkit-tap-highlight-color:rgba(0,0,0,0)}
 canvas{position:absolute;top:0;left:0;display:block;width:100%;height:100%;}
 .panel{position:absolute;padding:4px 8px;background:rgba(0,0,0,0.3);backdrop-filter:blur(6px);text-shadow:0 0 6px currentColor;border:1px solid rgba(255,255,255,0.1);white-space:pre}
 #meta{top:4px;left:4px}


### PR DESCRIPTION
## Summary
- prevent text selection and default gestures
- disable mobile selection with CSS
- connect generated rooms with corridors

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6863129212348332bdac02f8287da65c