### PR TITLE
Fix initial spawn and always connect rooms

### DIFF
--- a/map3d.js
+++ b/map3d.js
@@ -59,6 +59,13 @@ function init(){
   loadedChunks['0,0']=level;
   loadedCells['0,0']=generateOrgan(0,0);
 
+  // spawn player at the center of the first generated cell so we are not stuck
+  const first = loadedCells['0,0'][0];
+  if(first){
+    camera.position.x = first.x + 0.5;
+    camera.position.z = first.y + 0.5;
+  }
+
   const boxGeo = new THREE.BoxGeometry(0.5,0.5,0.5);
   const boxMat = new THREE.MeshNormalMaterial();
   for(let i=0;i<5;i++){

--- a/organGen.js
+++ b/organGen.js
@@ -55,14 +55,9 @@ function mulberry32(a){
 
 function edgeOpen(cx,cy,dir){
   // dir:0=N,1=E,2=S,3=W
-  let ax=cx,ay=cy,bx=cx,by=cy;
-  if(dir===0) ay--;
-  else if(dir===1) bx++;
-  else if(dir===2) by++;
-  else if(dir===3) ax--;
-  let h=ax*73856093^ay*19349663^bx*83492791^by*1640531513^worldSeed;
-  h=Math.imul(h^h>>>13,1274126177);
-  return (h>>>15)&1;
+  // previously edge openings were random which could isolate rooms. always open
+  // all edges so chunks seamlessly connect with corridors
+  return 1;
 }
 
 function listFirst(set){


### PR DESCRIPTION
## Summary
- connect all chunk edges so rooms are never isolated
- spawn player at the first generated cell instead of origin to avoid being trapped

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68631963e2c48332a1a39b76b635465e