### PR TITLE
Fix player movement boundaries and corridor generation

### DIFF
--- a/main.js
+++ b/main.js
@@ -96,7 +96,11 @@ const BULLET_R=0.015;
 let chunkX=0,chunkY=0;
 const loadedChunks={};
 const firstCells=generateOrgan(0,0);
-loadedChunks['0,0']=firstCells.map(t=>AABB(t.x*CHUNK_SIZE,t.y*CHUNK_SIZE,CHUNK_SIZE,CHUNK_SIZE));
+loadedChunks['0,0']=firstCells.map(t=>
+  AABB(t.x*CHUNK_SIZE-PLAYER_R,
+       t.y*CHUNK_SIZE-PLAYER_R,
+       CHUNK_SIZE+PLAYER_R*2,
+       CHUNK_SIZE+PLAYER_R*2));
 
 const enemyTypes={
   normal:{speed:0.1,hp:10},
@@ -264,7 +268,11 @@ function loop(ts){
     chunkX=cxx;chunkY=cyy;
     const key=cxx+','+cyy;
     if(!loadedChunks[key]){
-      const cells=generateOrgan(cxx,cyy).map(t=>AABB(t.x*CHUNK_SIZE,t.y*CHUNK_SIZE,CHUNK_SIZE,CHUNK_SIZE));
+      const cells=generateOrgan(cxx,cyy).map(t=>
+        AABB(t.x*CHUNK_SIZE-PLAYER_R,
+             t.y*CHUNK_SIZE-PLAYER_R,
+             CHUNK_SIZE+PLAYER_R*2,
+             CHUNK_SIZE+PLAYER_R*2));
       loadedChunks[key]=cells;
       console.log('generate',key,cells);
     }

--- a/map3d.js
+++ b/map3d.js
@@ -145,7 +145,9 @@ function animate(){
   const allBoxes=[];
   for(const k in loadedCells){
     const cells=loadedCells[k];
-    for(const c of cells) allBoxes.push(AABB(c.x,c.y,1,1));
+    for(const c of cells) {
+      allBoxes.push(AABB(c.x-PLAYER_R, c.y-PLAYER_R, 1+PLAYER_R*2, 1+PLAYER_R*2));
+    }
   }
   let inside=false;
   for(const box of allBoxes){if(circleInsideAABB(player,box)){inside=true;break;}}

--- a/organGen.js
+++ b/organGen.js
@@ -92,19 +92,18 @@ export function generateOrgan(cx,cy){
     centers.push(center);
     prevCenter=center;
   }
-  // connect to edges
-  const central={x:Math.floor(SIZE/2),y:Math.floor(SIZE/2)};
-  dig(central.x,central.y);
-  centers.forEach(c=>connect(c,central));
+  // connect to edges using nearest room center for a more maze-like feel
   const dirs=[[0,-1],[1,0],[0,1],[-1,0]];
   for(let i=0;i<4;i++){
     if(edgeOpen(cx,cy,i)){
-      let x=central.x,y=central.y;
-      while(x>=0&&x<SIZE&&y>=0&&y<SIZE){
-        dig(x,y);
-        x+=dirs[i][0];
-        y+=dirs[i][1];
+      const ex = i===1?SIZE-1:i===3?0:Math.floor(rnd()*SIZE);
+      const ey = i===0?0:i===2?SIZE-1:Math.floor(rnd()*SIZE);
+      let best=centers[0],bestDist=Infinity;
+      for(const c of centers){
+        const d=Math.abs(c.x-ex)+Math.abs(c.y-ey);
+        if(d<bestDist){bestDist=d;best=c;}
       }
+      connect(best,{x:ex,y:ey});
     }
   }
   return cells;


### PR DESCRIPTION
## Summary
- allow moving between cells by expanding walkable AABBs
- generate corridors from random rooms to chunk edges for ant‑hill style levels

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68631e9b4e1c83329fabfd5277ae6031