### PR TITLE
Add limb hitzones and shooting flash

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -86,7 +86,7 @@ function drawEnemies(arr,color,size){
   gl.drawArrays(gl.POINTS,0,arr.length);
 }
 
-export function renderFrame(dt,bullets,enemies,blood,items,map,bulletSize,mapCellSize){
+export function renderFrame(dt,bullets,enemies,blood,items,map,bulletSize,mapCellSize,flashes=[]){
   time += dt;
   baseFov=getRules().FOV||1;
   const pulse = 0.5 + Math.sin(time*3.0)*0.5;
@@ -105,6 +105,7 @@ export function renderFrame(dt,bullets,enemies,blood,items,map,bulletSize,mapCel
   const eCol=[0.6+Math.sin(time*2.0)*0.4,0,0];
   drawEnemies(enemies,eCol,18.0);
   drawPoints(bullets,[1,0,0.3],bulletSize);
+  drawPoints(flashes,[1,0.8,0],bulletSize*2.0);
   drawPoints(items,[0,0.8,1.0],8.0);
   drawPoints(blood,[0.8*pulse,0,0],4.0);
 }


### PR DESCRIPTION
## Summary
- add muzzle flash effect and track flash particles
- expand enemy objects with limb data and per-limb hit logic
- animate enemy limbs
- draw flashes and limb points in the engine
- check collisions against enemy limbs and player

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68638f8a77b483329893f1affc904757