### PR TITLE
Fix canvas layering and improve 3D rendering DPI

### DIFF
--- a/map3d.js
+++ b/map3d.js
@@ -37,6 +37,7 @@ function init(){
     document.body.appendChild(canvas);
   }
   renderer = new THREE.WebGLRenderer({canvas});
+  renderer.setPixelRatio(window.devicePixelRatio);
   renderer.setSize(window.innerWidth, window.innerHeight);
   crosshair = document.getElementById('crosshair');
   raycaster = new THREE.Raycaster();
@@ -89,6 +90,7 @@ function init(){
 function onResize(){
   camera.aspect = window.innerWidth/window.innerHeight;
   camera.updateProjectionMatrix();
+  renderer.setPixelRatio(window.devicePixelRatio);
   renderer.setSize(window.innerWidth, window.innerHeight);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,7 @@
 html,body{width:100vw;height:100vh;margin:0;overflow:hidden;touch-action:none;background:#050505;background:radial-gradient(circle,#0a0015,#050505);color:#faffff;font-family:monospace;-webkit-user-select:none;-ms-user-select:none;user-select:none;-webkit-touch-callout:none;-webkit-tap-highlight-color:rgba(0,0,0,0)}
 canvas{position:absolute;top:0;left:0;display:block;width:100%;height:100%;}
+#gl{z-index:1;}
+#gl3d{z-index:0;pointer-events:none;}
 .panel{position:absolute;padding:4px 8px;background:rgba(0,0,0,0.3);backdrop-filter:blur(6px);text-shadow:0 0 6px currentColor;border:1px solid rgba(255,255,255,0.1);white-space:pre}
 #meta{top:4px;left:4px}
 #fps{bottom:4px;right:4px}


### PR DESCRIPTION
## Summary
- ensure the 2D gameplay canvas sits above the 3D background canvas
- disable events on the 3D canvas so pointer lock works
- render Three.js scene at device pixel ratio for crisp output

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6863b6b0afb08332a0dd74e6c2344996