### PR TITLE
Expose computeWalls and add tests

### DIFF
--- a/__tests__/computeWalls.test.js
+++ b/__tests__/computeWalls.test.js
@@ -1,0 +1,49 @@
+import { generateOrgan, edgeOpen, edgeCoord, CELLS_PER_CHUNK } from '../organGen.js';
+import { computeWalls } from '../map3d.js';
+
+function findWall(walls, target){
+  return walls.some(w => w.x===target.x && w.y===target.y && w.w===target.w && w.h===target.h);
+}
+
+describe('computeWalls', () => {
+  test('limits walls per cell', () => {
+    const cx=0, cy=0;
+    const cells=generateOrgan(cx,cy);
+    const walls=computeWalls(cells,cx,cy);
+    expect(walls.length).toBeLessThanOrEqual(cells.length*4);
+  });
+
+  test('respects edge openings', () => {
+    const cx=0, cy=0;
+    const cells=generateOrgan(cx,cy);
+    const walls=computeWalls(cells,cx,cy);
+    const SIZE=CELLS_PER_CHUNK;
+    const edgeCoords=[edgeCoord(cx,cy,0),edgeCoord(cx,cy,1),edgeCoord(cx,cy,2),edgeCoord(cx,cy,3)];
+    const edgeOpenings=[edgeOpen(cx,cy,0),edgeOpen(cx,cy,1),edgeOpen(cx,cy,2),edgeOpen(cx,cy,3)];
+    const W=0.1;
+    if(edgeOpenings[0]){
+      const x=edgeCoords[0]+cx*SIZE;
+      const y=cy*SIZE;
+      const expected={x:x-0.5,y:y-0.5-W,w:1,h:W};
+      expect(findWall(walls, expected)).toBe(false);
+    }
+    if(edgeOpenings[1]){
+      const x=cx*SIZE+SIZE-1;
+      const y=edgeCoords[1]+cy*SIZE;
+      const expected={x:x-0.5+1,y:y-0.5,w:W,h:1};
+      expect(findWall(walls, expected)).toBe(false);
+    }
+    if(edgeOpenings[2]){
+      const x=edgeCoords[2]+cx*SIZE;
+      const y=cy*SIZE+SIZE-1;
+      const expected={x:x-0.5,y:y-0.5+1,w:1,h:W};
+      expect(findWall(walls, expected)).toBe(false);
+    }
+    if(edgeOpenings[3]){
+      const x=cx*SIZE;
+      const y=edgeCoords[3]+cy*SIZE;
+      const expected={x:x-0.5-W,y:y-0.5,w:W,h:1};
+      expect(findWall(walls, expected)).toBe(false);
+    }
+  });
+});

--- a/map3d.js
+++ b/map3d.js
@@ -119,7 +119,7 @@ function onKeyUp(e){
   }
 }
 
-function computeWalls(cells,cx,cy){
+export function computeWalls(cells,cx,cy){
   const set=new Set(cells.map(c=>c.x+','+c.y));
   const WALL=0.1;
   const walls=[];

--- a/organGen.js
+++ b/organGen.js
@@ -79,9 +79,9 @@ function listFirst(set){
   return null;
 }
 
-export const floorGeo = new THREE.PlaneGeometry(1,1);
+const floorGeo = new THREE.PlaneGeometry(1,1);
 floorGeo.rotateX(-Math.PI/2);
-export const wallGeo = new THREE.PlaneGeometry(1,2);
+const wallGeo = new THREE.PlaneGeometry(1,2);
 
 export function generateOrgan(cx,cy){
   const cells=[];


### PR DESCRIPTION
## Summary
- export `computeWalls` from `map3d.js`
- export geometry helpers once in `organGen.js`
- test wall generation behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68705ca5c8ec833288cef4b96e5c9833