### PR TITLE
fix: rotate floor plane, lift walls – 3-D render back

### DIFF
--- a/organGen.js
+++ b/organGen.js
@@ -131,7 +131,8 @@ export function generateTunnelMesh(cx,cy,THREE){
   if(!floorGeo){
     floorGeo=new THREE.PlaneGeometry(1,1);
     floorGeo.rotateX(-Math.PI/2);
-    wallGeo=new THREE.PlaneGeometry(1,2);
+    wallGeo=new THREE.BoxGeometry(1,2,0.1);
+    wallGeo.translate(0,1,0);
   }
   if(!floorMat){
     floorMat=new THREE.MeshStandardMaterial({color:0x7a0a0a,emissive:0x110000,side:THREE.DoubleSide});


### PR DESCRIPTION
## Summary
- rotate floor geometry right after creation
- use BoxGeometry for walls and move base to floor level

## Testing
- `npm test`
- `npx http-server -p 8080 -c-1`

------
https://chatgpt.com/codex/tasks/task_e_687108a89ec88332b7ea8f8a725923e1