### PR TITLE
Fix blood movement timing

### DIFF
--- a/__tests__/goreSim.test.js
+++ b/__tests__/goreSim.test.js
@@ -29,6 +29,19 @@ describe('gore simulation', () => {
     expect(getBlood().length).toBeLessThan(initialLength);
   });
 
+  test('updateBlood moves particles based on dt', () => {
+    spawnBlood(0, 0, 'normal', 1);
+    const b = getBlood()[0];
+    const startX = b.x;
+    const startY = b.y;
+    const dt = 0.5;
+    const dx = b.dx;
+    const dy = b.dy;
+    updateBlood(dt);
+    expect(b.x).toBeCloseTo(startX + dx * dt);
+    expect(b.y).toBeCloseTo(startY + dy * dt);
+  });
+
   test('applyBloodEffects damages nearby entities', () => {
     const enemy = { x: 0, y: 0, hp: 5, speed: 1 };
     const player = { x: 0, y: 0, hp: 5 };

--- a/goreSim.js
+++ b/goreSim.js
@@ -25,7 +25,7 @@ export function spawnBlood(x,y,state='normal',amount=10){
 
 export function updateBlood(dt){
   blood.forEach(p=>{
-    p.x+=p.dx; p.y+=p.dy; p.life-=dt;
+    p.x+=p.dx*dt; p.y+=p.dy*dt; p.life-=dt;
     if(p.state==='burning') p.life-=dt*0.5;
     if(p.state==='frozen') p.life-=dt*0.2;
     if(p.state==='acidic') p.life-=dt*0.3;


### PR DESCRIPTION
## Summary
- adjust blood particle updates to use frame delta
- test blood particle movement scaling with dt

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687280507f5c83329d774675181772b6