### PR TITLE
Fix crosshair locking and reduce wall duplication

### DIFF
--- a/main.js
+++ b/main.js
@@ -51,13 +51,21 @@ if(!hasTouch){
   });
   document.addEventListener('pointerlockchange',()=>{
     locked=document.pointerLockElement===canvas3d;
+    if(locked){
+      cx=window.innerWidth/2;
+      cy=window.innerHeight/2;
+      cross.style.left='50%';
+      cross.style.top='50%';
+    }
   });
+  // keep crosshair centered while locked
   document.addEventListener('mousemove',e=>{
     if(!locked)return;
-    cx=Math.min(window.innerWidth,Math.max(0,cx+e.movementX));
-    cy=Math.min(window.innerHeight,Math.max(0,cy+e.movementY));
-    cross.style.left=cx+'px';
-    cross.style.top=cy+'px';
+    // prevent crosshair drift
+    cx=window.innerWidth/2;
+    cy=window.innerHeight/2;
+    cross.style.left='50%';
+    cross.style.top='50%';
   });
 } 
 else {

--- a/map3d.js
+++ b/map3d.js
@@ -57,7 +57,8 @@ export function init3D(){
   setSeed(0);
 
   camera = new THREE.PerspectiveCamera(75, window.innerWidth/window.innerHeight, 0.1, 100);
-  camera.position.y = 1.6;
+  // raise spawn slightly to avoid clipping through the floor
+  camera.position.y = 1.8;
 
   controls = new PointerLockControls(camera, canvas);
   canvas.addEventListener('click', () => controls.lock());
@@ -163,7 +164,24 @@ function loadChunk(cx,cz){
     scene.add(mesh);
     loadedChunks[key]=mesh;
     loadedCells[key]=generateOrgan(cx,cz);
-    loadedWalls[key]=computeWalls(loadedCells[key],cx,cz);
+    let newWalls=computeWalls(loadedCells[key],cx,cz);
+    // remove duplicates that may occur when neighbouring chunks generate the
+    // same wall geometry
+    for(const oKey in loadedWalls){
+      const other=loadedWalls[oKey];
+      for(let i=newWalls.length-1;i>=0;i--){
+        const w=newWalls[i];
+        for(let j=other.length-1;j>=0;j--){
+          const ow=other[j];
+          if(w.x===ow.x&&w.y===ow.y&&w.w===ow.w&&w.h===ow.h){
+            other.splice(j,1);
+            newWalls.splice(i,1);
+            break;
+          }
+        }
+      }
+    }
+    loadedWalls[key]=newWalls;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep the crosshair centred while the pointer is locked
- raise initial camera height
- remove duplicate walls when neighbouring chunks load

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687282c30da0833298c4d1b6b2a01584