### PR TITLE
Improve player movement and add camera bobbing

### DIFF
--- a/main.js
+++ b/main.js
@@ -260,7 +260,8 @@ function loop(ts){
   const rules=getRules();
   let ax=(keys['d']?1:0)-(keys['a']?1:0)+moveJoy.x;
   let ay=(keys['s']?1:0)-(keys['w']?1:0)+moveJoy.y;
-  let accel=0.6*(sprint?1.8:1);
+  // Increase player acceleration for faster movement
+  let accel=0.9*(sprint?1.8:1);
   if(ax||ay && slideTimer<=0){
     const l=Math.hypot(ax,ay);ax/=l;ay/=l;
     player.vx+=ax*accel*dt;

--- a/map3d.js
+++ b/map3d.js
@@ -27,7 +27,10 @@ let crosshair;
 let lastShot = 0;
 let level;
 let moveForward=false, moveBackward=false, moveLeft=false, moveRight=false;
-let velocity=3;
+// Base walking speed (increased for faster movement)
+let velocity=4.5;
+const baseCameraY = 1.8;
+let bobTime = 0;
 const CHUNK_SIZE=8;
 const loadedChunks={};
 const loadedCells={};
@@ -66,7 +69,7 @@ export function init3D(){
 
   camera = new THREE.PerspectiveCamera(75, window.innerWidth/window.innerHeight, 0.1, 100);
   // raise spawn slightly to avoid clipping through the floor
-  camera.position.y = 1.8;
+  camera.position.y = baseCameraY;
 
   controls = new PointerLockControls(camera, canvas);
   canvas.addEventListener('click', () => controls.lock());
@@ -282,6 +285,12 @@ export function update3D(delta){
   if(moveBackward) controls.moveForward(-velocity*delta);
   if(moveLeft) controls.moveRight(-velocity*delta);
   if(moveRight) controls.moveRight(velocity*delta);
+
+  const moving = moveForward || moveBackward || moveLeft || moveRight || Math.abs(getMoveJoy().x)>0.01 || Math.abs(getMoveJoy().y)>0.01;
+  if(moving) bobTime += delta * 8;
+  else bobTime -= delta * 8;
+  bobTime = Math.max(0, bobTime);
+  camera.position.y = baseCameraY + Math.sin(bobTime) * 0.05;
 
   // collision detection using wall geometry
   const player={x:camera.position.x,y:camera.position.z,r:PLAYER_R};


### PR DESCRIPTION
## Summary
- boost player acceleration speed
- increase 3D movement velocity
- implement simple camera bobbing effect when moving

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68765bccc4208332bbbdf84306573988