### PR TITLE
Restrict rendering debug logs to dev mode

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -134,7 +134,9 @@ export function renderFrame(dt,bullets,enemyGroups,blood,items,map,bulletSize,ma
   drawPoints(items,[0,0.8,1.0],8.0);
   drawPoints(blood,[0.8*pulse,0,0],4.0);
   const enemyCount=(enemyGroups||[]).reduce((s,g)=>s+g.points.length,0);
-  console.log(`Render: bullets ${bullets.length}, enemies ${enemyCount}, blood ${blood.length}, items ${items.length}, map ${map.length}, FOV ${camFov.toFixed(2)}`);
+  if(devMode){
+    console.log(`Render: bullets ${bullets.length}, enemies ${enemyCount}, blood ${blood.length}, items ${items.length}, map ${map.length}, FOV ${camFov.toFixed(2)}`);
+  }
 }
 
 export function setGlitch(state){

--- a/main.js
+++ b/main.js
@@ -291,7 +291,9 @@ function loop(ts){
              CHUNK_SIZE+PLAYER_R*2,
              CHUNK_SIZE+PLAYER_R*2));
       loadedChunks[key]=cells;
-      console.log('generate',key,cells);
+      if(dev){
+        console.log('generate',key,cells);
+      }
     }
   }
   for(let i=bullets.length-1;i>=0;i--){


### PR DESCRIPTION
## Summary
- show render diagnostics only in dev mode
- log chunk generation only in dev mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68767304a3e88332a2fa9fb6c88adf99